### PR TITLE
fix: azure provider secret parsing to match GCP pattern

### DIFF
--- a/cloud_secrets/providers/azure_provider.py
+++ b/cloud_secrets/providers/azure_provider.py
@@ -30,8 +30,8 @@ class AzureSecretsProvider(BaseSecretProvider):
         """Fetch raw secret from Azure Key Vault."""
         try:
             response = self.client.get_secret(secret_name)
-            # Create an env file format that environ can parse
-            self.env.read_env(io.StringIO(f"{secret_name}={response.value}"))
+            self.env.read_env(io.StringIO(response.value), overwrite=True)
+            self.env.ENVIRON[secret_name] = response.value
             return response.value
         except ResourceNotFoundError:
             raise SecretNotFoundError(f"Secret {secret_name} not found")


### PR DESCRIPTION
## Problem

Azure provider `_fetch_raw_secret` wraps the entire multi-line secret value as a single env var:
```python
self.env.read_env(io.StringIO(f"{secret_name}={response.value}"))
```

This creates `REDACTO-USER-SETTINGS=DATABASE_ENGINE=...` which:
1. Hyphens are invalid in env var names
2. Multi-line key=value pairs are not parsed into individual env vars

Result: `Failed to initialize environment` on Azure deployments.

## Fix

Match the GCP provider pattern — parse the secret value directly as key=value pairs:
```python
self.env.read_env(io.StringIO(response.value), overwrite=True)
self.env.ENVIRON[secret_name] = response.value
```