### PR TITLE
fix: robust secret loading across Azure and on-prem

### DIFF
--- a/cloud_secrets/providers/azure_provider.py
+++ b/cloud_secrets/providers/azure_provider.py
@@ -1,5 +1,6 @@
 # cloud_secrets/providers/azure_provider.py
 import io
+import re
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.keyvault.secrets import SecretClient
@@ -9,6 +10,17 @@ from cloud_secrets.common.exceptions import (
     SecretNotFoundError,
     ConfigurationError,
 )
+
+
+# Matches a dotenv line: a comment, or `KEY=` (optionally `export KEY=`).
+_DOTENV_LINE = re.compile(r"^\s*(?:#|(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=)")
+
+
+def _is_dotenv_blob(text: str) -> bool:
+    """Whether text is a dotenv config blob (every non-blank line is KEY=VALUE),
+    as opposed to a JSON or scalar secret value."""
+    lines = [line for line in text.splitlines() if line.strip()]
+    return bool(lines) and all(_DOTENV_LINE.match(line) for line in lines)
 
 
 class AzureSecretsProvider(BaseSecretProvider):
@@ -30,9 +42,14 @@ class AzureSecretsProvider(BaseSecretProvider):
         """Fetch raw secret from Azure Key Vault."""
         try:
             response = self.client.get_secret(secret_name)
-            # Create an env file format that environ can parse
-            self.env.read_env(io.StringIO(f"{secret_name}={response.value}"))
-            return response.value
+            value = response.value or ""
+            # get_secret() reads the value back by name; store it verbatim because
+            # Key Vault names contain dashes, which read_env cannot use as a key.
+            self.env.ENVIRON[secret_name] = value
+            # Config blobs are dotenv; parse them so get_env() exposes each key.
+            if _is_dotenv_blob(value):
+                self.env.read_env(io.StringIO(value))
+            return value
         except ResourceNotFoundError:
             raise SecretNotFoundError(f"Secret {secret_name} not found")
         except Exception as e:

--- a/cloud_secrets/providers/azure_provider.py
+++ b/cloud_secrets/providers/azure_provider.py
@@ -12,15 +12,25 @@ from cloud_secrets.common.exceptions import (
 )
 
 
-# Matches a dotenv line: a comment, or `KEY=` (optionally `export KEY=`).
-_DOTENV_LINE = re.compile(r"^\s*(?:#|(?:export\s+)?[A-Za-z_][A-Za-z0-9_]*\s*=)")
+# Must mirror django-environ's read_env acceptance EXACTLY: `#` only at column 0,
+# and a strict `KEY=` / `export KEY=` with no surrounding whitespace. read_env
+# logs every line it rejects verbatim at WARNING ("Invalid line: %s"), so any
+# line that passes a looser gate than this but read_env then rejects would leak
+# the secret in plaintext. Keep this a strict prefix of read_env's own regex.
+_DOTENV_LINE = re.compile(r"\A(?:#|(?:export )?[A-Za-z_0-9]+=)")
 
 
 def _is_dotenv_blob(text: str) -> bool:
-    """Whether text is a dotenv config blob (every non-blank line is KEY=VALUE),
-    as opposed to a JSON or scalar secret value."""
+    """Whether text is a MULTI-KEY dotenv config blob — every non-blank line is a
+    comment or KEY=VALUE, and there is more than one assignment. A single
+    `KEY=value` line (e.g. `PASSWORD=abc`) is a scalar secret, not a blob: it
+    stays verbatim under the Key Vault secret name instead of being split into
+    an env key. JSON and other scalar values fail the per-line match."""
     lines = [line for line in text.splitlines() if line.strip()]
-    return bool(lines) and all(_DOTENV_LINE.match(line) for line in lines)
+    if not lines or not all(_DOTENV_LINE.match(line) for line in lines):
+        return False
+    assignments = [line for line in lines if not line.lstrip().startswith("#")]
+    return len(assignments) > 1
 
 
 class AzureSecretsProvider(BaseSecretProvider):
@@ -43,10 +53,10 @@ class AzureSecretsProvider(BaseSecretProvider):
         try:
             response = self.client.get_secret(secret_name)
             value = response.value or ""
-            # get_secret() reads the value back by name; store it verbatim because
-            # Key Vault names contain dashes, which read_env cannot use as a key.
+            # Store verbatim so BaseSecretProvider.get_secret() reads it back by
+            # name: Key Vault names contain dashes, which read_env can't use as a
+            # dotenv key, so the value can't round-trip through read_env.
             self.env.ENVIRON[secret_name] = value
-            # Config blobs are dotenv; parse them so get_env() exposes each key.
             if _is_dotenv_blob(value):
                 self.env.read_env(io.StringIO(value))
             return value

--- a/cloud_secrets/providers/local_provider.py
+++ b/cloud_secrets/providers/local_provider.py
@@ -1,9 +1,12 @@
 import json
+import logging
 import os
 from pathlib import Path
 
 from .base import BaseSecretProvider
 from cloud_secrets.common.exceptions import ConfigurationError, SecretNotFoundError
+
+logger = logging.getLogger(__name__)
 
 
 class LocalEnvProvider(BaseSecretProvider):
@@ -13,16 +16,21 @@ class LocalEnvProvider(BaseSecretProvider):
         """Initialize local environment provider."""
         super().__init__()
         self.env_path = kwargs.get("env_path", ".env")
-        # Read the env file when present; otherwise fall back to the process
-        # environment (populated via envFrom). One mode serves a mounted file
-        # or plain env vars.
+        # Fall back to the process environment (populated via envFrom) when no
+        # env file is mounted.
         if os.path.exists(self.env_path):
             try:
                 self.env.read_env(self.env_path)
+                logger.info("local provider: loaded env file %s", self.env_path)
             except Exception as e:
                 raise ConfigurationError(
                     f"Failed to initialize local provider: {str(e)}"
                 )
+        else:
+            logger.info(
+                "local provider: no env file at %s; using process environment",
+                self.env_path,
+            )
 
     def _get_secrets_file_path(self) -> Path:
         return Path(self.env_path).parent / ".secrets.json"

--- a/cloud_secrets/providers/local_provider.py
+++ b/cloud_secrets/providers/local_provider.py
@@ -13,12 +13,16 @@ class LocalEnvProvider(BaseSecretProvider):
         """Initialize local environment provider."""
         super().__init__()
         self.env_path = kwargs.get("env_path", ".env")
-        if not os.path.exists(self.env_path):
-            raise ConfigurationError(f"Environment file not found: {self.env_path}")
-        try:
-            self.env.read_env(self.env_path)
-        except Exception as e:
-            raise ConfigurationError(f"Failed to initialize local provider: {str(e)}")
+        # Read the env file when present; otherwise fall back to the process
+        # environment (populated via envFrom). One mode serves a mounted file
+        # or plain env vars.
+        if os.path.exists(self.env_path):
+            try:
+                self.env.read_env(self.env_path)
+            except Exception as e:
+                raise ConfigurationError(
+                    f"Failed to initialize local provider: {str(e)}"
+                )
 
     def _get_secrets_file_path(self) -> Path:
         return Path(self.env_path).parent / ".secrets.json"

--- a/tests/test_azure_provider.py
+++ b/tests/test_azure_provider.py
@@ -1,0 +1,99 @@
+"""Regression tests for AzureSecretsProvider.get_secret read-back.
+
+The bug this guards: dash-named secrets holding a JSON blob (the vendor CSV
+connector's S3/SFTP credentials, keyed `csv-connector-<org>-<config>` on Azure)
+came back EMPTY because get_secret round-tripped them through django-environ's
+dotenv parser, which rejects dash keys and JSON — and logged the raw secret as
+an "Invalid line". Empty creds then surfaced downstream as S3 AccessDenied.
+
+These tests fail if the fix in azure_provider.py is reverted.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from azure.core.exceptions import ResourceNotFoundError
+
+from cloud_secrets.providers.azure_provider import _is_dotenv_blob
+
+
+def _provider_with_secrets(secrets: dict):
+    """An AzureSecretsProvider whose Key Vault returns the given {name: value}.
+
+    Patches the module-bound SecretClient/DefaultAzureCredential (bound at
+    import, so patching azure.* directly would miss them) and injects a mock
+    client. Import is local so a missing azure SDK skips rather than errors the
+    whole module.
+    """
+    from cloud_secrets.providers.azure_provider import AzureSecretsProvider
+
+    def _get(name):
+        if name not in secrets:
+            raise ResourceNotFoundError(f"{name} not found")
+        m = MagicMock()
+        m.value = secrets[name]
+        return m
+
+    with patch("cloud_secrets.providers.azure_provider.DefaultAzureCredential"), patch(
+        "cloud_secrets.providers.azure_provider.SecretClient"
+    ) as mock_cls:
+        client = MagicMock()
+        client.get_secret.side_effect = _get
+        mock_cls.return_value = client
+        return AzureSecretsProvider(vault_url="https://test.vault.azure.net/")
+
+
+def test_dash_named_json_secret_returns_verbatim():
+    """The CSV-connector case: a dash-named JSON secret must round-trip verbatim
+    (this is the exact value that came back empty before the fix)."""
+    creds = {
+        "access_key_id": "AKIAEXAMPLE",
+        "secret_access_key": "s3cr3t/EXAMPLE",
+        "bucket": "vendor-csv",
+    }
+    name = "csv-connector-org-ec7ef774-1c4b-4f38-8823-df654dcf42b3"
+    provider = _provider_with_secrets({name: json.dumps(creds)})
+
+    raw = provider.get_secret(name)
+    assert json.loads(raw) == creds
+
+
+def test_multiline_dotenv_blob_still_exposes_keys():
+    """A genuine multi-key dotenv config blob is still parsed into env keys."""
+    blob = "APP_NAME=MyApp\nDEBUG=true\nPORT=8080"
+    provider = _provider_with_secrets({"app-config": blob})
+
+    provider.get_secret("app-config")
+    assert provider.env("APP_NAME") == "MyApp"
+    assert provider.env.int("PORT") == 8080
+
+
+def test_single_scalar_key_value_stays_verbatim():
+    """A single `KEY=value` line is a scalar, not a blob: returned verbatim and
+    NOT split into an env key (CodeRabbit finding)."""
+    provider = _provider_with_secrets({"db-password": "PASSWORD=abc"})
+
+    assert provider.get_secret("db-password") == "PASSWORD=abc"
+    assert "PASSWORD" not in provider.env.ENVIRON  # never loaded as a key
+
+
+def test_loose_line_is_not_parsed_so_no_leak():
+    """A line read_env would reject (spaces around '=') must NOT pass the gate,
+    so it is stored verbatim and never handed to read_env (which would log the
+    secret at WARNING). Zaid's security finding."""
+    value = "API_KEY = sk-live-supersecret"
+    provider = _provider_with_secrets({"api": value})
+
+    assert provider.get_secret("api") == value
+    assert "API_KEY" not in provider.env.ENVIRON
+
+
+def test_is_dotenv_blob_classification():
+    """Direct unit coverage of the classifier the fix hinges on."""
+    assert _is_dotenv_blob("A=1\nB=2") is True
+    assert _is_dotenv_blob("# header\nA=1\nB=2") is True
+    assert _is_dotenv_blob("PASSWORD=abc") is False          # single scalar
+    assert _is_dotenv_blob("API_KEY = sk-live-x") is False   # loose line
+    assert _is_dotenv_blob('{"a": "b"}') is False            # JSON
+    assert _is_dotenv_blob("opaque-token") is False          # scalar
+    assert _is_dotenv_blob("") is False


### PR DESCRIPTION
Two changes to make secret loading correct across environments; only the Azure and local providers are touched, AWS and GCP are unchanged.

1. Azure read-back (azure_provider.py). get_secret() read values back by keying the secret name into django-environ's dotenv parser, which rejects dash-containing keys. Azure Key Vault names use dashes, so dynamic secrets (e.g. the vendor CSV connector S3/SFTP credentials, stored as JSON) came back empty on Azure and the raw secret was logged as an invalid line. Store the value verbatim on the environ so get_secret returns it as-is, and only feed genuine dotenv config blobs to read_env (passing the blob directly, not name=blob).

2. Local env-var fallback (local_provider.py). The local provider required an env file and crashed when it was missing, so backend services could only take config from a mounted file on-prem. Now it reads the file when present and otherwise falls back to the process environment (populated via envFrom). One local mode serves either a mounted file or plain env vars, matching the frontend and fitting both SaaS and bank setups. Applies to every backend service (userservice, vendor, consent, compliance, agentic, matrix) since all use provider_type=local through the same path.

Follow-up: add test_azure_provider.py for coverage.